### PR TITLE
Add support for distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Consider the following HTML snippet:
 ```
-<rise-page id="page" display-id="dummy-id">
+<rise-page id="page" display-id="abc123">
   <rise-playlist id="playlist-1" intro="fade-in" outro="fade-out">
     <rise-playlist-item duration="3">
       <demo-component id="apple" src="https://url.to.apple.png"></demo-component>
@@ -27,6 +27,27 @@ Consider the following HTML snippet:
 
 In the above example, `apple` and `balloons` both play for 3 seconds. After that, `duck` and `moon` play for 5 seconds. In this way, both playlists are synchronized such that they start and end at the exact same time.
 
+### Distribution
+The [distribution component](https://github.com/Rise-Vision/web-component-rise-distribution) can be used to control whether or not a Playlist shows on a Display. If any of the values in its `distribution` attribute match the value of the page component's `display-id` attribute, the playlist will play. Otherwise, the playlist will be hidden from view and will not play.
+
+In the following example, `playlist-1` will play since it has a distribution that matches that of the page component, while `playlist-2` will be skipped as none of its distributions match.
+```
+<rise-page id="page" display-id="abc123">
+  <rise-playlist id="playlist-1" intro="fade-in" outro="fade-out">
+    <rise-playlist-item duration="3">
+      <demo-component id="apple" src="https://url.to.apple.png"></demo-component>
+    </rise-playlist-item>
+    <rise-distribution distribution='[{"id":"abc123"}]'></rise-distribution>
+  </rise-playlist>
+  <rise-playlist id="playlist-2" intro="fade-in" outro="fade-out">
+    <rise-playlist-item duration="5">
+      <demo-component id="duck" src="https://url.to.duck.png"></demo-component>
+    </rise-playlist-item>
+    <rise-distribution distribution='[{"id":"dummy-id"},{"id":"no-match"}]'></rise-distribution>
+  </rise-playlist>
+</rise-page>
+```
+
 In addition, `rise-page` surfaces methods for returning details about the Display.
 
 `rise-page` works in conjunction with [Rise Vision](http://www.risevision.com), the [digital signage management application](http://rva.risevision.com/) that runs on [Google Cloud](https://cloud.google.com).
@@ -34,11 +55,12 @@ In addition, `rise-page` surfaces methods for returning details about the Displa
 At this time Chrome is the only browser that this project and Rise Vision supports.
 
 ## Usage
-To begin, you will need to install `rise-page`, `rise-playlist` and `rise-playlist-item` using Bower:
+To begin, you will need to install the following components using Bower:
 ```
 bower install https://github.com/Rise-Vision/web-component-rise-page.git
 bower install https://github.com/Rise-Vision/web-component-rise-playlist.git
 bower install https://github.com/Rise-Vision/web-component-rise-playlist-item.git
+bower install https://github.com/Rise-Vision/web-component-rise-distribution.git
 ```
 
 The above repositories, as well as their dependencies, are installed in the `bower_components` folder.
@@ -52,14 +74,16 @@ Next, construct your HTML page. You should include `webcomponents-lite.min.js` b
     <link rel="import" href="bower_components/web-component-rise-page/rise-page.html">
     <link rel="import" href="bower_components/web-component-rise-playlist/rise-playlist.html">
     <link rel="import" href="bower_components/web-component-rise-playlist-item/rise-playlist-item.html">
+    <link rel="import" href="bower_components/web-component-rise-distribution/rise-distribution.html">
   </head>
   <body>
-    <!-- Replace "dummy-id" with a valid Display ID. -->
-    <rise-page id="page" display-id="dummy-id">
+    <!-- Replace "abc123" with a valid Display ID. -->
+    <rise-page id="page" display-id="abc123">
       <rise-playlist id="playlist-1">
         <rise-playlist-item duration="5">
           <!-- Content goes here. -->
         </rise-playlist-item>
+        <rise-distribution distribution='[{"id":"abc123"}]'></rise-distribution>
       </rise-playlist>
     </rise-page>
   </body>
@@ -185,7 +209,17 @@ localhost:8080/components/rise-page/test/
 ```
 
 ### Deployment
-Once you are satisifed with your changes, deploy `rise-page.html`, as well as the `bower_components/iron-ajax`, `bower_components/polymer`, `bower_components/promise-polyfill`, and `bower_components/webcomponentsjs` folders to your server. You can then use the web component by following the *Usage* instructions above.
+Once you are satisifed with your changes, deploy `rise-page.html`, as well as the following folders to your server:
+* `bower_components/iron-ajax`
+* `bower_components/polymer`
+* `bower_components/promise-polyfill`
+* `bower_components/rise-distribution`
+* `bower_components/rise-page`
+* `bower_components/rise-playlist`
+* `bower_components/rise-playlist-item`
+* `bower_components/webcomponentsjs`
+
+You can then use the web component by following the *Usage* instructions above.
 
 ## Submitting Issues
 If you encounter problems or find defects we really want to hear about them. If you could take the time to add them as issues to this Repository it would be most appreciated. When reporting issues, please use the following format where applicable:

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "underscore": "~1.8.3"
   },
   "devDependencies": {
+    "rise-distribution": "https://github.com/Rise-Vision/web-component-rise-distribution.git",
     "rise-playlist": "https://github.com/Rise-Vision/web-component-rise-playlist.git",
     "rise-playlist-item": "https://github.com/Rise-Vision/web-component-rise-playlist-item.git#1.0.2",
     "web-component-tester": "~3.1.3"

--- a/demo.html
+++ b/demo.html
@@ -6,10 +6,11 @@
 
   <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
 
-  <link rel="import" href="rise-page.html">
   <link rel="import" href="demo-component.html">
+  <link rel="import" href="rise-page.html">
   <link rel="import" href="../rise-playlist/rise-playlist.html">
   <link rel="import" href="../rise-playlist-item/rise-playlist-item.html">
+  <link rel="import" href="../rise-distribution/rise-distribution.html">
 
   <style>
     rise-playlist {
@@ -48,6 +49,8 @@
       <rise-playlist-item duration="5">
         <demo-component id="duck" src="https://goo.gl/fyZFTU"></demo-component>
       </rise-playlist-item>
+
+      <rise-distribution distribution='[{"id":"VGZUDDWYAZHY"}]'></rise-distribution>
     </rise-playlist>
 
     <rise-playlist id="playlist-2" intro="fade-in" outro="fade-out">
@@ -58,6 +61,7 @@
       <rise-playlist-item duration="5">
         <demo-component id="moon" src="https://goo.gl/VyUVhj"></demo-component>
       </rise-playlist-item>
+
     </rise-playlist>
 
   </rise-page>

--- a/rise-page.html
+++ b/rise-page.html
@@ -6,7 +6,6 @@
 <dom-module id="rise-page">
   <template>
     <content id="playlists" select="rise-playlist"></content>
-    <content id="items" select="rise-playlist-item"></content>
 
     <iron-ajax id="display"
       url={{_computeUrl(displayId)}}
@@ -98,7 +97,7 @@
     },
 
     /**
-     * * Store additional details about a playlist.
+     * Store additional details about a playlist.
      */
     _handleReady: function(e) {
       var playlist = _.findWhere(this._allPlaylists, { id: e.target.id });
@@ -108,16 +107,71 @@
         return;
       }
 
-      playlist.isReady = true;
+      // Check the distribution to see if the playlist should play on this Display.
+      if (this._canPlay(playlist)) {
+        playlist.isReady = true;
 
-      if (e.detail && e.detail.items) {
-        playlist.items = e.detail.items;
+        if (e.detail && e.detail.items) {
+          playlist.items = e.detail.items;
+        }
+      }
+      // Hide and remove the playlist from the master array of playlists.
+      else {
+        playlist.element.style.display = "none";
+        this._allPlaylists = _.without(this._allPlaylists, playlist);
       }
 
       this._numPlaylists++;
 
       if (this._numPlaylists === this._totalPlaylists) {
         this._start();
+      }
+    },
+
+    /**************************************** DISTRIBUTION ****************************************/
+
+    /**
+     * Determine whether or not to play a playlist based on its distribution and the Display ID.
+     */
+    _canPlay: function(playlist) {
+      var nodes = null,
+        node = null,
+        distribution = null,
+        found = false;
+
+      // Find the rise-distribution element for the playlist.
+      if (playlist.element) {
+        nodes = playlist.element.childNodes;
+
+        for (var i = 0; i < nodes.length; i++) {
+          node = nodes[i];
+
+          if ((node.nodeType === 1) && (node.nodeName === "RISE-DISTRIBUTION")) {
+            found = true;
+
+            // Check if any of the distribution values match the Display ID.
+            try {
+              distribution = JSON.parse(node.getAttribute("distribution"));
+
+              for (var j = 0; j < distribution.length; j++) {
+                if (distribution[j].id === this.getDisplayId()) {
+                  return true;
+                }
+              }
+            }
+            catch (e) {
+              console.log(e);
+            }
+          }
+        }
+      }
+
+      // Play the playlist even if there is no rise-distribution element.
+      if (!found) {
+        return true;
+      }
+      else {
+        return false;
       }
     },
 
@@ -200,9 +254,9 @@
 
       // Check the duration of the next playlist items.
       this.play(this._getGroupedPlaylists(nextIndex, playlists));
-     },
+    },
 
-    /*************************************** DISPLAY INFO ***************************************/
+    /**************************************** DISPLAY INFO ****************************************/
 
     /**
      * Return the Display ID.

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,9 @@
   <body>
     <script>
       WCT.loadSuites([
+        "integration/rise-page.html",
         "unit/rise-page-display-info.html",
+        "unit/rise-page-distribution.html",
         "unit/rise-page-helper.html",
         "unit/rise-page-init.html",
         "unit/rise-page-playback.html"

--- a/test/integration/rise-page.html
+++ b/test/integration/rise-page.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-page</title>
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../../rise-playlist/rise-playlist.html">
+  <link rel="import" href="../../../rise-playlist-item/rise-playlist-item.html">
+  <link rel="import" href="../../../rise-distribution/rise-distribution.html">
+  <link rel="import" href="../../rise-page.html">
+  <link rel="import" href="../../demo-component.html">
+</head>
+<body>
+  <rise-page id="page" display-id="dummy-id">
+
+    <rise-playlist id="match">
+
+      <rise-playlist-item>
+        <demo-component></demo-component>
+      </rise-playlist-item>
+
+      <rise-distribution distribution='[{"id":"dummy-id"}]'></rise-distribution>
+
+    </rise-playlist>
+
+    <rise-playlist id="no-match">
+
+      <rise-playlist-item>
+        <demo-component></demo-component>
+      </rise-playlist-item>
+
+      <rise-distribution distribution='[{"id":"abc123"}]'></rise-distribution>
+
+    </rise-playlist>
+
+    <rise-playlist id="no-distribution">
+
+      <rise-playlist-item>
+        <demo-component></demo-component>
+      </rise-playlist-item>
+
+    </rise-playlist>
+
+  </rise-page>
+
+  <script>
+    suite("rise-page", function() {
+      var page = document.getElementById("page"),
+        matchSpy, noMatchSpy, noDistSpy;
+
+      suiteSetup(function() {
+        var items = document.getElementsByTagName("demo-component");
+
+        matchSpy = sinon.spy(page._allPlaylists[0].element, "play");
+        noMatchSpy = sinon.spy(page._allPlaylists[1].element, "play");
+        noDistSpy = sinon.spy(page._allPlaylists[2].element, "play");
+
+        for (var i = 0; i < items.length; i++) {
+          items[i].onReady();
+        }
+      });
+
+      suiteTeardown(function() {
+        page._allPlaylists[0].element.play.restore();
+        page._allPlaylists[1].element.play.restore();
+      });
+
+      test("should play a playlist if it has a distribution matching the Display ID", function() {
+        assert(matchSpy.calledOnce);
+      });
+
+      test("should not play a playlist if it does not have a distribution matching the Display ID", function() {
+        assert(noMatchSpy.notCalled);
+      });
+
+      test("should play a playlist if it does not have a distribution", function() {
+        assert(noDistSpy.calledOnce);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/unit/rise-page-distribution.html
+++ b/test/unit/rise-page-distribution.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Page - Distribution</title>
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.min.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../../rise-playlist/rise-playlist.html">
+  <link rel="import" href="../../../rise-playlist-item/rise-playlist-item.html">
+  <link rel="import" href="../../../rise-distribution/rise-distribution.html">
+  <link rel="import" href="../../rise-page.html">
+  <link rel="import" href="../../demo-component.html">
+</head>
+<body>
+  <rise-page id="page" display-id="dummy-id">
+
+    <rise-playlist id="match">
+
+      <rise-playlist-item>
+        <demo-component></demo-component>
+      </rise-playlist-item>
+
+      <rise-distribution distribution='[{"id":"dummy-id"}]'></rise-distribution>
+
+    </rise-playlist>
+
+    <rise-playlist id="no-match">
+
+      <rise-playlist-item>
+        <demo-component></demo-component>
+      </rise-playlist-item>
+
+      <rise-distribution distribution='[{"id":"abc123"}]'></rise-distribution>
+
+    </rise-playlist>
+
+    <rise-playlist id="no-distribution">
+
+      <rise-playlist-item>
+        <demo-component></demo-component>
+      </rise-playlist-item>
+
+    </rise-playlist>
+
+  </rise-page>
+
+  <script>
+    suite("distribution", function() {
+      var page = document.getElementById("page");
+
+      suiteSetup(function() {
+        var items = document.getElementsByTagName("demo-component");
+
+        for (var i = 0; i < items.length; i++) {
+          items[i].onReady();
+        }
+      });
+
+      suite("_canPlay", function() {
+        var playlist = null;
+
+        test("should return true if a playlist has a distribution matching the Display ID", function() {
+          playlist = page._getPlaylistObj(document.getElementById("match"));
+
+          assert.isTrue(page._canPlay(playlist));
+        });
+
+        test("should return false if a playlist does not have a distribution matching the Display ID", function() {
+          playlist = page._getPlaylistObj(document.getElementById("no-match"));
+
+          assert.isFalse(page._canPlay(playlist));
+        });
+
+        test("should return true if a playlist does not have a distribution", function() {
+          playlist = page._getPlaylistObj(document.getElementById("no-distribution"));
+
+          assert.isTrue(page._canPlay(playlist));
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/unit/rise-page-init.html
+++ b/test/unit/rise-page-init.html
@@ -10,6 +10,7 @@
 
   <link rel="import" href="../../../rise-playlist/rise-playlist.html">
   <link rel="import" href="../../../rise-playlist-item/rise-playlist-item.html">
+  <link rel="import" href="../../../rise-distribution/rise-distribution.html">
   <link rel="import" href="../../rise-page.html">
   <link rel="import" href="../../demo-component.html">
 </head>
@@ -44,15 +45,22 @@
 
     </rise-playlist>
 
+    <rise-playlist id="playlist-3">
+
+      <rise-playlist-item duration="5">
+        <demo-component id="item-5"></demo-component>
+      </rise-playlist-item>
+
+      <rise-distribution distribution='[{"id":"abc123"}]'></rise-distribution>
+
+    </rise-playlist>
+
     Ignore this text.
   </rise-page>
 
   <script>
     suite("page", function() {
-      var page = document.querySelector("#page"),
-        playlist1 = document.querySelector("#playlist-1"),
-        item1 = document.querySelector("#item-1"),
-        item2 = document.querySelector("#item-2");
+      var page = document.getElementById("page");
 
       suite("_computeUrl", function() {
         test("should return the correct URL for a given displayId", function() {
@@ -62,18 +70,18 @@
 
       suite("attached", function() {
         test("should create an array of objects representing each rise-playlist element", function() {
-          assert.equal(page._allPlaylists.length, 2);
+          assert.equal(page._allPlaylists.length, 3);
         });
 
         test("should set the total number of playlists", function() {
-          assert.equal(page._totalPlaylists, 2);
+          assert.equal(page._totalPlaylists, 3);
         });
       });
 
       suite("_handleReady", function() {
         suiteSetup(function() {
-          item1.onReady();
-          item2.onReady();
+          document.getElementById("item-1").onReady();
+          document.getElementById("item-2").onReady();
         });
 
         test("should set isReady", function() {
@@ -90,9 +98,20 @@
 
         test("should not increment the total number of ready playlists if the playlist has " +
           "already reported ready", function() {
-          playlist1.dispatchEvent(new CustomEvent("rise-playlist-ready", { "bubbles": true }));
+          document.getElementById("playlist-1").dispatchEvent(new CustomEvent("rise-playlist-ready", { "bubbles": true }));
 
           assert.equal(page._numPlaylists, 1);
+        });
+
+        test("should remove playlist from _allPlaylists if Display ID does not exist in the " +
+          "distribution", function() {
+          document.getElementById("item-5").onReady();
+
+          assert.equal(page._allPlaylists.length, 2);
+        });
+
+        test("should hide playlist if distribution does not match Display ID", function() {
+          assert.equal(document.getElementById("playlist-3").style.display, "none");
         });
       });
     });

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -1,5 +1,6 @@
 module.exports = {
   verbose: true,
+  expanded: true,
   plugins: {
     local: {
       browsers: ["chrome"]


### PR DESCRIPTION
If a playlist has a `rise-distribution` child element, the page component will check its `distribution` attribute to see if any of its values match that of the page component's `display-id` attribute. If a match is found, or if a playlist does not have a `rise-distribution` child element, the playlist will play. If a match is not found, then that playlist will be skipped and hidden from view.
